### PR TITLE
Update landing page: remove links, badge, update blog URL, add logo spacing

### DIFF
--- a/app/LandingPage.tsx
+++ b/app/LandingPage.tsx
@@ -552,7 +552,7 @@ function LandingPage() {
               alt="Learn With Me Series"
               width={320}
               height={220}
-              className="mx-auto w-28 md:w-28"
+              className="mx-auto mb-8 w-28 md:w-28"
             />
             {/* Header */}
             <div className="mb-12 flex flex-col items-start gap-4 md:flex-row md:items-end md:justify-between">


### PR DESCRIPTION
## Summary

- Remove "Full history" link from Experience section and "All projects" link from Projects section
- Remove "YouTube Show" badge from the Learn With Me Series section
- Update all blog article links from `favouritejome.hashnode.dev` to `blog.favouritejome.dev`
- Add spacing (`mb-8`) between the Learn With Me logo and the description text

## Test plan

- [ ] Experience and Projects sections still render correctly without their header links
- [ ] Series section displays without the "YouTube Show" badge
- [ ] Article links (cards + "All articles") point to `blog.favouritejome.dev`
- [ ] Logo in the Series section has visible space above the description text

https://claude.ai/code/session_01Uftj64SpVNkAoVSeJSs4JG