### PR TITLE
Fix Writing section: replace paywalled Hashnode GraphQL API with RSS feed

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": true
+    }
+  ]
+}

--- a/app/api/blog/route.ts
+++ b/app/api/blog/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+
+export interface Post {
+  title: string;
+  slug: string;
+  publishedAt: string;
+  coverImage: { url: string } | null;
+}
+
+const FEED_URL = "https://blog.favouritejome.dev/rss.xml";
+
+function decodeEntities(text: string): string {
+  return text
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function stripCData(text: string): string {
+  const match = text.match(/<!\[CDATA\[([\s\S]*?)\]\]>/);
+  return decodeEntities(match ? match[1] : text);
+}
+
+function parseItems(xml: string): Post[] {
+  const posts: Post[] = [];
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match;
+
+  while ((match = itemRegex.exec(xml)) !== null) {
+    const item = match[1];
+
+    const rawTitle = (item.match(/<title>([\s\S]*?)<\/title>/) ?? [])[1];
+    const link = (item.match(/<link>([\s\S]*?)<\/link>/) ?? [])[1];
+    const pubDate = (item.match(/<pubDate>([\s\S]*?)<\/pubDate>/) ?? [])[1];
+    const coverUrl = (item.match(/<enclosure url="(.*?)"/) ?? [])[1];
+
+    if (!rawTitle || !link) continue;
+
+    const slug = new URL(link).pathname.replace(/^\//, "");
+
+    posts.push({
+      title: stripCData(rawTitle),
+      slug,
+      publishedAt: pubDate ?? "",
+      coverImage: coverUrl ? { url: coverUrl } : null,
+    });
+  }
+
+  return posts;
+}
+
+export async function GET() {
+  try {
+    const res = await fetch(FEED_URL, { next: { revalidate: 3600 } });
+    const xml = await res.text();
+    const posts = parseItems(xml).slice(0, 6);
+
+    return NextResponse.json(posts);
+  } catch {
+    return NextResponse.json({ error: "Failed to fetch posts" }, { status: 500 });
+  }
+}

--- a/hooks/useBlogPost.tsx
+++ b/hooks/useBlogPost.tsx
@@ -1,38 +1,12 @@
 import axios from "axios";
 import { useQuery } from "@tanstack/react-query";
+import type { Post } from "../app/api/blog/route";
 
-const endpoint = "https://gql.hashnode.com/";
+export type { Post as PostResponse };
 
-const ARTICLE_QUERY = `
-  {
-    publication(host: "favouritejome.hashnode.dev") {
-      posts(first: 6) {
-        edges {
-          node {
-            title
-            slug
-            publishedAt
-            coverImage {
-              url
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-export interface PostResponse {
-  title: string;
-  slug: string;
-  publishedAt: string;
-  coverImage?: { url: string } | null;
-}
-
-const getArticle = async (): Promise<PostResponse[]> => {
-  const response = await axios.post(endpoint, { query: ARTICLE_QUERY });
-  const edges = response.data.data.publication.posts.edges as { node: PostResponse }[];
-  return edges.map((edge) => edge.node);
+const getArticle = async (): Promise<Post[]> => {
+  const { data } = await axios.get<Post[]>("/api/blog");
+  return data;
 };
 
 export const useBlogPost = (_username?: string) => {


### PR DESCRIPTION
## Summary
- Hashnode retired free GraphQL API access. Testing confirmed `gql.hashnode.com` now unconditionally `301`-redirects every request (regardless of query or auth) to a Hashnode changelog page announcing that all GraphQL reads/writes require a paid Pro plan as of May 13, 2026. There is no free replacement endpoint, so the Writing section on the homepage was silently rendering nothing.
- Switched the data source to `blog.favouritejome.dev/rss.xml`, which is still public and free.
- Since the RSS feed has no CORS headers, a direct client-side fetch would fail in the browser, so added `app/api/blog/route.ts` — a server-side route handler that fetches and regex-parses the feed into `{ title, slug, publishedAt, coverImage }`. This mirrors the existing `app/api/youtube/route.ts` pattern already used in this repo for the same class of problem.
- `hooks/useBlogPost.tsx` now calls `/api/blog` instead of the dead GraphQL endpoint. `PostResponse` shape is unchanged, so `components/ArticleCard.tsx` needed no changes.
- Added `.claude/launch.json` (dev server preview config) used to verify this fix locally.

## Test plan
- [x] Started the dev server and loaded the homepage
- [x] Confirmed `/api/blog` returns 200 with correct JSON matching the live RSS feed (6 real posts: title, slug, publishedAt, coverImage)
- [x] Verified via DOM inspection that all 6 posts render in the `#writing` section with correct titles, dates, and cover images
- [x] `tsc --noEmit` passes clean across the whole project (including the unused legacy `components/Articles.tsx` which also imports from this hook)